### PR TITLE
Add Italian (it) localization support

### DIFF
--- a/l10n/bundle.l10n.it.json
+++ b/l10n/bundle.l10n.it.json
@@ -1,0 +1,6 @@
+{
+    "Open a file first to {0} text": "Aprire prima un file per {0} il testo",
+    "copy": "copiare",
+    "cut": "tagliare",
+    "paste": "incollare"
+}

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -1,0 +1,11 @@
+{
+    "copy-word.commands.copy.title": "Copy Word: Copia",
+    "copy-word.commands.cut.title": "Copy Word: Taglia",
+    "copy-word.commands.paste.title": "Copy Word: Incolla",
+    "copy-word.configuration.title": "Copy Word in Cursor",
+    "copy-word.configuration.useOriginalCopyBehavior.description": "Usa il comportamento originale di Taglia/Copia quando non è selezionato alcun testo e non è definita alcuna parola corrente.",
+    "copy-word.configuration.pasteWordBehavior.description": "Indica il comportamento del comando Incolla.",
+    "copy-word.configuration.pasteWordBehavior.enumDescriptions.original": "Il comportamento originale di VS Code (incolla la parola nella posizione del cursore).",
+    "copy-word.configuration.pasteWordBehavior.enumDescriptions.replaceWordAtCursor": "Sostituisce la parola corrente con il contenuto degli appunti.",
+    "copy-word.configuration.pasteWordBehavior.enumDescriptions.replaceWordAtCursorWhenInTheMiddleOfTheWord": "Sostituisce la parola corrente con il contenuto degli appunti solo quando il cursore è nel mezzo della parola."
+}


### PR DESCRIPTION
Closes #83

## Changes

- Added `package.nls.it.json` with Italian translations for all manifest contributions (commands, settings, enum descriptions)
- Added `l10n/bundle.l10n.it.json` with Italian translations for all runtime messages

## Validation

- All keys from `package.nls.json` are present and translated
- All keys from `l10n/bundle.l10n.json` are present and translated (including `{0}` placeholder preserved)
- `npm run build` — ✅ compiled successfully
- `npm run lint` — ✅ no new errors (pre-existing warnings only)